### PR TITLE
Ignore fontconfig .uuid generation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+# Ignore fontconfig .uuid files
+.uuid


### PR DESCRIPTION
I'm incorporating fonts like so: https://github.com/tony/dot-fonts
After running `sudo fc-cache -fv` a `.uuid` file was generated in this folder.

### Details

*from https://github.com/powerline/fonts/pull/288*

If using powerlevel10k-media via a git submodule, certain linux systems may
generate .uuid files. This prevents accidentally committing these
artifacts in case a user doesn't have it in ~.gitignore_global.

See also:
- https://forum.antergos.com/topic/9573/uuid-files-being-created-fonts
- https://www.freedesktop.org/software/fontconfig/fontconfig-devel/fcdircachecreateuuid.html
- https://github.com/powerline/fonts/commit/1f2225f5bec566b79d086735bfc02a663702fcbc